### PR TITLE
flash_messageの実装修正

### DIFF
--- a/app/controllers/habit_checks_controller.rb
+++ b/app/controllers/habit_checks_controller.rb
@@ -14,7 +14,7 @@ class HabitChecksController < ApplicationController
 
       # turbo_stream(非同期)と同期処理のレスポンス
       respond_to do |format|
-        format.turbo_stream
+        format.turbo_stream { flash.now[:notice] = "完了を記録しました" }
         format.html { redirect_back fallback_location: dashboard_path, notice: "完了を記録しました" }
       end
     else
@@ -33,7 +33,7 @@ class HabitChecksController < ApplicationController
     set_checks_by_habit # その習慣の最新の１週間分のhabit_checks情報を持ってきて表示
 
     respond_to do |format|
-      format.turbo_stream
+      format.turbo_stream { flash.now[:notice] = "完了を取り消しました" }
       format.html { redirect_back fallback_location: dashboard_path, notice: "完了を取り消しました" }
     end
   end

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -2,7 +2,38 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="flash"
 export default class extends Controller {
-  close() {
-    this.element.remove() // 画面から削除
+  static values = { timeout: Number } // html側のdata-flash-timeout-valueの値をNumber(整数値)で受け取る。timeoutNumberが使えるようになる。
+
+  connect() {
+
+    requestAnimationFrame(() => {
+      // translate-x-full をremoveで外して、addでtranslate-x-0を挿入する。→スライドイン。
+      this.element.classList.remove("translate-x-full") // translate-x-full(右に100%押し出す→画面外)
+      this.element.classList.add("translate-x-0")  // taranslate-x-0 (元の位置)
+    })
+
+    // 自動で閉じる時間(デフォルトは5秒)
+    const ms = this.timeoutValue || 5000
+    this.autoHideTimer = setTimeout(() => this.close(), ms)
+  }
+
+  disconnect() {
+    // DOM から消えるときはタイマーをクリア
+    if (this.autoHideTimer) clearTimeout(this.autoHideTimer)
+  }
+
+  close(event) {
+    // 明示的にボタンから来た場合は event がある。preventDefault は不要だが念のため
+    if (event && typeof event.preventDefault === "function") event.preventDefault()
+
+    // スライドアウト：右に戻す
+    this.element.classList.remove("translate-x-0")
+    this.element.classList.add("translate-x-full")
+
+    // transition duration の時間待ってから要素を削除（400ms に合わせる）
+    setTimeout(() => {
+      // 親要素から remove（Turbo Stream などの非同期でも DOM が更新される場合があるが、ここで直接消す）
+      this.element.remove()
+    }, 400)
   }
 }

--- a/app/views/habit_checks/create.turbo_stream.erb
+++ b/app/views/habit_checks/create.turbo_stream.erb
@@ -4,3 +4,9 @@
     <%= render partial: "habits/habit_card", formats: [:html], locals: { habit: @habit, week_dates: @week_dates, checks_by_habit: @checks_by_habit } %>
   </template>
 </turbo-stream>
+
+<turbo-stream action="append" target="flash-message">
+  <template>
+    <%= render partial: "shared/flash_message", locals: { notice: flash.now[:notice], alert: flash.now[:alert] }, formats: [:html] %>
+  </template>
+</turbo_stream>

--- a/app/views/habit_checks/destroy.turbo_stream.erb
+++ b/app/views/habit_checks/destroy.turbo_stream.erb
@@ -4,3 +4,9 @@
     <%= render partial: "habits/habit_card", formats: [:html], locals: { habit: @habit, week_dates: @week_dates, checks_by_habit: @checks_by_habit } %>
   </template>
 </turbo-stream>
+
+<turbo-stream action="append" target="flash-message">
+  <template>
+    <%= render partial: "shared/flash_message", locals: { notice: flash.now[:notice], alert: flash.now[:alert] }, formats: [:html] %>
+  </template>
+</turbo-stream>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,9 @@
     <!-- フラッシュメッセージを挿入 -->
     <%= render 'shared/flash_message' %>
 
+    <!-- turbo_stream用flash_messageを表示 -->
+    <div id="flash-message"></div>
+
     <%= yield %> <!-- 各viewが差し込まれる -->
 
     <!-- フッター挿入-->

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,7 +1,11 @@
 <% flash.each do |message_type, message| %>
   <% next if message.blank? %> <%# messageが空の時はスキップ %>
-    <div class="w-full fixed flex justify-betwwen items-center absolute top-[70px] px-5 py-3 rounded-lg shadow-lg text-white transition-all duration-500 <%= message_type == 'notice' ? 'bg-green-500' : 'bg-red-500' %>" data-controller="flash"> <%# 三項演算子で分岐, Stimulusで動的処理 %>
-      <span><%= message %></span>
-      <button class="ml-4 text-white font-bold text-lg hover:text-gray-200" data-action="click->flash#close">✖︎</button> <%# Stimulusでクリック→閉じるを処理 %>
+    <div class="fixed top-4 right-4 z-50 transform translate-x-full transition-transform duration-400 ease-out max-w-xs w-full shadow-lg rounded-lg overflow-hidden <%= message_type == "notice" ? "bg-green-400 text-white" : "bg-red-400 text-white" %>" data-controller="flash" data-flash-timeout-value ="10000" role="status" aria-live="polite"> <%# 三項演算子で分岐, Stimulusで動的処理 %>
+      <div class="px-4 py-3 flex justify-between items-center gap-3">
+        <div class="flex-1 text-sm">
+          <%= message %>
+        </div>
+      <button type="button" class="text-white/90 hover:text-white rounded transition px-2 py-1" data-action="click->flash#close" aria-label="dismiss">✕</button> <%# Stimulusでクリック→閉じるを処理 %>
+      </div>
     </div>
 <% end %>


### PR DESCRIPTION
stimulesを使ったflash_messageの動的表示
flash_controller.jsを編集
フラッシュメッセージが右上からスライドで表示され、10秒経つとスライドで消えていくよう実装
turbo_stream用フラッシュ実装
すでに作ってあった_flash_message.html.erbをformats: [:html]で持ってきて、表示。
チェックする、チェックを外す処理をするとフラッシュが同じように表示されるように実装。