### PR TITLE
カレンダー表示機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,6 @@ gem "devise"
 # i18n導入
 gem "rails-i18n"
 gem "devise-i18n"
+
+# カレンダー機能
+gem "simple_calendar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -352,6 +354,7 @@ DEPENDENCIES
   rails-i18n
   rubocop-rails-omakase
   selenium-webdriver
+  simple_calendar
   sprockets-rails
   stimulus-rails
   tailwindcss-rails (~> 4.4)

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,11 @@
 @import "tailwindcss";
+
+/* カレンダーを横幅いっぱいに広げるようレイアウトを強制的に整える */
+.simple-calendar table {
+    @apply w-full table-fixed;
+}
+
+  .simple-calendar th,
+  .simple-calendar td {
+    @apply w-[14.28%];
+  }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,6 +7,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # 独自カラム[:name]も編集できるように、 strong parametersに追加
   def configure_permitted_parameters
+    # 新規登録の際、nameを許可
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    # 更新処理の際、nameを許可
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,8 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @user = current_user # 現在ログインしているユーザー情報取得
+    @user = current_user # ユーザー情報取得
+    @month = params[:month] ? Date.parse(params[:month]) : Date.current
+    @habit_checks = current_user.habit_checks.includes(:habit).where(checked_on: @month.beginning_of_month..@month.end_of_month) # 今ログインしているユーザーのチェック状況・習慣情報(タイトルなど)を取得 カレンダー表示のため
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,7 +6,6 @@
       <%= link_to "➕新しい習慣", new_habit_path, class: "block bg-green-300 text-center font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
       <%= link_to "習慣一覧", habits_path, class: "block bg-green-300 text-center font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
       <%= link_to "マイページ", mypage_path(@user), class: "block bg-green-300 text-center font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
-      <%= link_to "設定", "#", class: "block bg-green-300 text-center font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
     </nav>
   </aside>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,3 +15,6 @@
     <% end %>
   </div>
 </div>
+<div class="flex justify-start ml-10 mb-5">
+  <%= link_to "戻る", mypage_path, class: "bg-lime-300 hover:bg-lime-600 text-white font-semibold py-3 px-5 rounded-lg shadow-md transition" %>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,36 @@
+<div class="simple-calendar">
+  <!-- simple_calendarのデフォルトヘッダーをコメントアウトして、使わない設定 -->
+  <!--
+  <div class="calendar-heading">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+  -->
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,17 +1,63 @@
-<div class="min-h-screen flex items-center justify-center p-6 bg-gradient-to-b from-green-50 to-white">
-  <div class="w-full items-center max-w-md bg-white rounded-2xl shadow-lg p-6">
+<div class="min-h-screen flex flex-col items-center p-6 bg-gradient-to-b from-green-50 to-white">
 
+  <!-- ▼▼ マイページ上部カード ▼▼ -->
+  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-6 mb-10">
     <h2 class="text-2xl font-bold text-green-700 text-center mb-6">🌱 マイページ 🌱</h2>
 
-    <!-- ユーザー情報カード内容 -->
     <p class="text-lg text-gray-800 mb-2">名前：<%= @user.name %></p>
-
     <p class="text-gray-600 mb-4">メールアドレス：<%= @user.email %></p>
 
-    <!-- 編集ボタン -->
     <div class="flex mt-6 justify-end">
       <%= link_to "編集", edit_user_registration_path,
-            class: "inline-block bg-green-500 hover:bg-green-600 text-white font-semibold px-4 py-2 rounded-lg shadow" %>
+          class: "inline-block bg-green-500 hover:bg-green-600 text-white font-semibold px-4 py-2 rounded-lg shadow" %>
     </div>
   </div>
+
+
+  <!-- ▼▼ カレンダー ▼▼ -->
+  <div class="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8">
+
+    <!-- 🔥 カレンダーヘッダー（手動で作成） -->
+    <div class="flex justify-between items-center mb-6">
+
+      <!-- 左：月表示 -->
+      <h2 class="text-2xl font-bold text-green-700">
+        <%= l @month, format: "%Y年 %m月" %>
+      </h2>
+
+      <!-- 右：ナビゲーション -->
+      <div class="space-x-4">
+        <%= link_to "← 前の月", mypage_path(@user, month: @month.prev_month),
+              class: "text-green-600 hover:text-green-800 font-semibold" %>
+
+        <%= link_to "今日", mypage_path(@user, month: Date.current),
+              class: "text-green-600 hover:text-green-800 font-semibold" %>
+
+        <%= link_to "次の月 →", mypage_path(@user, month: @month.next_month),
+              class: "text-green-600 hover:text-green-800 font-semibold" %>
+      </div>
+    </div>
+
+
+    <!-- ▼▼ カレンダー本体 ▼▼ -->
+    <%= month_calendar events: @habit_checks, attribute: :checked_on do |date, checks| %>
+
+      <div class="border-2 border-green-100 h-32 w-full p-2 rounded hover:bg-green-50 transition">
+        
+        <div class="text-sm font-semibold text-gray-500 mb-1"><%= date.day %></div>
+
+        <div class="space-y-1 overflow-hidden">
+          <% checks.each do |check| %>
+            <div class="text-xs bg-green-100 text-green-700 rounded px-1 py-0.5 truncate line-clamp-2 leading-tight">
+              <%= check.habit.title %>
+            </div>
+          <% end %>
+        </div>
+
+      </div>
+
+    <% end %>
+
+  </div>
+
 </div>


### PR DESCRIPTION
カレンダーをマイページに表示し、習慣の達成状況を可視化できるように実装
①simple_calendarを導入
②マイページに追記し、カレンダーを表示。attribute: :checked_onでchecked_onカラムから持ってくる。
③カレンダーには、チェックした日付に習慣タイトルが表示されるよう実装。
④simple_calendarのデフォルトヘッダーを、コメントアウトして、カスタムしたヘッダーを表示できるように実装。
