### PR TITLE
習慣の公開/非公開機能実装

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,6 +1,12 @@
 class HabitsController < ApplicationController
   before_action :authenticate_user! # ログインしているユーザーのみ
-  before_action :set_habits, only: %i[ show edit update destroy ]
+  before_action :set_habits, only: %i[ edit update destroy ]
+
+  # 習慣公開処理
+  def public_index
+    @habits = Habit.publicly_visible.includes(:user).order(created_at: :desc)
+    @week_start = Date.current.beginning_of_week(:monday) # 月曜開始
+  end
 
   def index
     @habits = current_user.habits.order(created_at: :desc)
@@ -10,7 +16,10 @@ class HabitsController < ApplicationController
     @habit = current_user.habits.build
   end
 
-  def show; end
+  def show
+    @habit = Habit.find_by(id: params[:id])
+    @week_start = Date.current.beginning_of_week(:monday) # 月曜開始
+  end
 
   def edit; end
 
@@ -41,7 +50,7 @@ class HabitsController < ApplicationController
   private
 
   def habit_params
-    params.require(:habit).permit(:title, :frequency, :start_date)
+    params.require(:habit).permit(:title, :frequency, :start_date, :is_public)
   end
 
   def set_habits

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -7,6 +7,9 @@ class Habit < ApplicationRecord
   # frequency 頻度enum管理(毎日・週に3回・週に1回)
   enum frequency: { daily: 0, three_times_week: 1, once_a_week: 2 }
 
+  # 公開されている習慣のみを取得する scope（ビューやコントローラで使う）。 publicly_visibleメソッドをシンボルで定義。
+  scope :publicly_visible, -> { where(is_public: true) }
+
   # 特定の習慣を特定のユーザーが特定の日にチェックしたかを返すメソッド
   def checked_on?(user, date)
     habit_checks.exists?(user: user, checked_on: date)

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -4,7 +4,8 @@
   <aside class="w-full lg:w-1/6 bg-white shadow-md p-4 lg:p-6 flex flex-col">
     <nav class="flex flex-wrap gap-3 lg:flex-col lg:space-y-6 grow">
       <%= link_to "➕新しい習慣", new_habit_path, class: "block bg-white border border-green-600 text-center font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
-      <%= link_to "習慣一覧", habits_path, class: "block bg-white text-center border border-green-600 font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
+      <%= link_to "マイ習慣", habits_path, class: "block bg-white text-center border border-green-600 font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
+      <%= link_to "みんなの習慣", public_habit_path, class: "block bg-white text-center border border-green-600 font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
       <%= link_to "みんなの自然", posts_path, class: "block bg-white text-center border border-green-600 font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
       <%= link_to "マイページ", mypage_path(@user), class: "block bg-white text-center border border-green-600 font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>
       <%= link_to "マイカレンダー", calendar_path(@user), class: "block bg-white text-center border border-green-600 font-medium hover:text-green-600 font-semibold py-3 px-3 rounded-lg shadow-md transition" %>

--- a/app/views/habits/_form.html.erb
+++ b/app/views/habits/_form.html.erb
@@ -1,12 +1,37 @@
 <%= form_with model: habit, local: true do |f| %>
   <div class="mb-5">
     <%= f.label :title, "習慣タイトル", class: "block text-gray font-bold mb-1" %>
-    <%= f.text_field :title, class: "w-full border-2 border-green-500 p-2 rounded-lg focus:ring-2 focus:ring-green-600 focus:outline-none", placeholder: "習慣タイトル" %>
+    <%= f.text_field :title, class: "w-full border-2 border-green-500 p-2 rounded-lg focus:ring-2 focus:ring-green-600 focus:outline-none", placeholder: "「自然公園に行く」などなど" %>
+    <p class="text-sm text-gray-500 mt-1">あなたが思う自然のことなら、どんなことでもOK!</p>
   </div>
 
   <div class="mb-5">
     <%= f.label :frequency, "頻度", class: "block text-gray font-bold mb-1" %>
     <%= f.select :frequency, Habit.frequencies.keys.map { |k| [t("activerecord.attributes.habit.frequency_values.#{k}"), k] }, {}, class: "w-full border-2 border-green-500 p-2 rounded-lg focus:ring-2 focus:ring-green-600 focus:outline-none" %>
+    <p class="text-sm text-gray-500 mb-1">日常の些細な自然なら「毎日」をお出かけが必要なら「週に1回」など、習慣に合わせて頻度を選択してください。</p>
+  </div>
+
+  <div class="mt-5">
+    <label class="block text-gray-700 font-bold mb-2">公開設定</label>
+
+    <label class="flex items-center cursor-pointer">
+      <!-- チェックボックス本体（隠す） -->
+      <%= f.check_box :is_public, class: "hidden peer" %>
+
+      <!-- スイッチ部分 -->
+      <div class="w-14 h-7 bg-gray-300 rounded-full peer-checked:bg-green-500 transition duration-300 relative">
+        <div class="absolute left-1 top-1 w-5 h-5 bg-white rounded-full transition duration-300 peer-checked:translate-x-7"></div>
+      </div>
+
+      <!-- 説明テキスト -->
+      <span class="ml-3 text-gray-700 font-semibold peer-checked:text-green-600">
+        公開する
+      </span>
+    </label>
+
+    <p class="text-sm text-gray-500 mt-1">
+      ※ 公開にすると「みんなの習慣」で習慣を共有できるようになります。
+    </p>
   </div>
 
   <div class="flex justify-end mt-3 mb-5">

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -1,6 +1,6 @@
 <div class="flex grow items-start justify-center p-8">
   <div class="w-full max-w-6xl">
-    <h1 class="text-center text-4xl font-bold text-green-700 mb-10">🌱習慣の一覧🌱</h1>
+    <h1 class="text-center text-4xl font-bold text-green-700 mb-10">🌱 マイ習慣 🌱</h1>
 
     <% if @habits.present? %>
       <!-- ▼ ここで 3列のグリッドレイアウトを作る -->
@@ -15,9 +15,19 @@
               <%= t("activerecord.attributes.habit.frequency_values.#{habit.frequency}") %>
             </p>
 
-            <p class="text-gray-700">
+            <p class="text-gray-700 mb-2">
               <span class="font-semibold">作成日：</span>
               <%= l habit.created_at.in_time_zone('Asia/Tokyo'), format: :short %>
+            </p>
+
+            <!-- 公開/非公開 -->
+            <p class="text-gray-700">
+              <span class="font-semibold">公開設定：</span>
+              <% if habit.is_public === true %>
+                公開
+              <% else %>
+                非公開
+              <% end %>
             </p>
 
             <!-- 習慣詳細ボタン(ローカル変数を渡す) -->

--- a/app/views/habits/public_index.html.erb
+++ b/app/views/habits/public_index.html.erb
@@ -1,0 +1,25 @@
+<div class="flex grow items-start justify-center p-8">
+  <div class="w-full max-w-6xl">
+    <h1 class="text-center text-4xl font-bold text-green-700 mb-10">🌱 みんなの習慣 🌱</h1>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+      <% @habits.each do |habit| %>
+        <div class="bg-white shadow-lg border-green-300 border-3 rounded-xl p-6 hover:shadow-2xl transition">
+
+          <h2 class="text-green-700 font-bold text-xl mb-4 hover:text-green-800"><%= link_to habit.title, habit_path(habit) %></h2>
+
+          <p class="text-gray-700 mb-2">ユーザー名: <%= habit.user.name %></p>
+
+          <p class="text-gray-700 mb-2">頻度: <%= t("activerecord.attributes.habit.frequency_values.#{habit.frequency}") %></p>
+
+          <div class="mb-2 text-gray-700">今週の達成率: <%= habit.achievement_rate(habit.user, @week_start) %>%</div>
+
+          <div class="w-full bg-gray-200 rounded-full h-3">
+            <div class="bg-green-500 h-3 rounded-full transition-all duration-500" style="width: <%= habit.achievement_rate(habit.user, @week_start) %>%;"></div>
+          </div>
+
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -6,6 +6,22 @@
   <!-- カード本体 -->
   <div class="w-full max-w-2xl bg-white shadow-xl border border-green-300 rounded-2xl p-8 flex flex-col space-y-6 hover:shadow-2xl transition">
 
+    <!-- 公開か非公開かを表示 -->
+    <div class="flex justify-between items-center">
+      <!-- ユーザー名表示 -->
+      <p class="text-gray-600 text-lg"><%= @habit.user.name %></p>
+
+      <% if @habit.is_public === true %>
+        <div class="border-2 border-green-600 text-white font-semibold bg-green-500 px-3 py-2 rounded-3xl">
+          公開中
+        </div>
+      <% else %>
+        <div class="border-2 border-gray-600 text-white font-semibold bg-gray-500 px-3 py-2 rounded-3xl">
+          非公開
+        </div>
+      <% end %>
+    </div>
+
     <!-- 習慣タイトル -->
     <h2 class="text-center text-gray-700 font-bold text-2xl">
       <span class="text-green-800">習慣タイトル：</span>
@@ -18,17 +34,29 @@
       <%= t("activerecord.attributes.habit.frequency_values.#{@habit.frequency}") %>
     </p>
 
+    <!-- 達成率 -->
+    <div class="mb-2 text-gray-700 font-semibold">
+      <span class="text-green-800">達成率: </span>
+        <%= @habit.achievement_rate(@habit.user, @week_start) %>%
+    </div>
+
+      <div class="w-full bg-gray-200 rounded-full h-3">
+        <div class="bg-green-500 h-3 rounded-full transition-all duration-500" style="width: <%= @habit.achievement_rate(@habit.user, @week_start) %>%;"></div>
+      </div>
+
     <!-- ボタン -->
     <div class="flex justify-center space-x-4 pt-4">
-      <%= link_to "編集", edit_habit_path(@habit),
-            class: "bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition" %>
+      <% if @habit.user === current_user %>
+        <%= link_to "編集", edit_habit_path(@habit),
+              class: "bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition" %>
 
-      <%= link_to "削除", habit_path(@habit),
-            data: { turbo_method: :delete, turbo_confirm: "削除しますか?" },
-            class: "bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition" %>
-      
-      <%= link_to "一覧に戻る", habits_path,
-            class: "bg-lime-300 hover:bg-lime-600 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition" %>
+        <%= link_to "削除", habit_path(@habit),
+              data: { turbo_method: :delete, turbo_confirm: "削除しますか?" },
+              class: "bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition" %>
+
+        <%= link_to "一覧に戻る", habits_path,
+              class: "bg-lime-300 hover:bg-lime-600 text-white font-semibold py-2 px-5 rounded-lg shadow-md transition" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -1,6 +1,6 @@
 <!-- メインコンテンツ -->
 <main class="grow mt-8 flex flex-col items-center justify-center text-center p-8" data-controller="reveal">
-  <h1 class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-green-700 mb-4 fade-in-up" data-reveal-target="item">🌱ようこそ NatureHabit へ🌱</h1>
+  <h1 class="text-3xl sm:text-2xl md:text-4xl lg:text-6xl font-bold text-green-700 mb-4 fade-in-up" data-reveal-target="item">🌱ようこそ NatureHabit へ🌱</h1>
 
   <p class="text-base sm:text-lg md:text-xl text-gray-600 mb-8 w-full max-w-md sm:max-w-xl mt-2 fade-in-up" data-reveal-target="item">
   NatureHabitは、「日常の中で自然と触れ合う習慣」を管理・可視化できるアプリです。</br>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,9 @@
 <header class="w-full bg-white shadow-md py-4 px-8 flex justify-between items-center">
   <div class="text-2xl font-bold text-green-700">
     <% if user_signed_in? %>
-      <%= link_to "NatureHabit", dashboard_path, class: "hover:text-green-600, transition" %>
+      <%= link_to "NatureHabit", dashboard_path, class: "hover:text-green-500 transition" %>
     <% else %>
-      <%= link_to "NatureHabit", root_path, class: "hover:text-green-600 transition" %>
+      <%= link_to "NatureHabit", root_path, class: "hover:text-green-500 transition" %>
     <% end %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,10 @@ Rails.application.routes.draw do
     resources :habit_checks, only: %i[ create destroy ] # habits_checksルート
   end
 
+  # 習慣公開ルート（みんなの習慣）
+
+  get "public_habit", to: "habits#public_index", as: :public_habit
+
   # postsルート
   resources :posts, only: %i[ index show new edit update create destroy ]
 

--- a/db/migrate/20251211041840_add_is_public_to_habits.rb
+++ b/db/migrate/20251211041840_add_is_public_to_habits.rb
@@ -1,0 +1,5 @@
+class AddIsPublicToHabits < ActiveRecord::Migration[7.2]
+  def change
+    add_column :habits, :is_public, :boolean, default: false, null: false # habitsテーブルに習慣の公開/非公開を選択できるよう追記。
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_10_024154) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_11_041840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_10_024154) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_public", default: false, null: false
     t.index ["user_id"], name: "index_habits_on_user_id"
   end
 

--- a/test/fixtures/habits.yml
+++ b/test/fixtures/habits.yml
@@ -7,11 +7,13 @@
 one:
   title: "朝の散歩"
   frequency: daily
+  is_public: true
   user: one
 # column: value
 #
 two:
   title: "植物の水やり"
   frequency: once_a_week
+  is_public: false
   user: two
 # column: value


### PR DESCRIPTION
習慣の公開・非公開機能の実装
habitテーブルにis_public(boolean)を追記し、trueとfalseでデータを公開か非公開かに識別。
defalutsはfalse, null: falseで設定。
→db:migrate
習慣公開場所のルート作成。コントローラー処理はhabitsコントローラーに追記。public_index。
public_index用のview作成・編集

今後はコメント機能・リアクション機能を実装予定。