### PR TITLE
リアクション(いいね機能)の実装

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,36 @@
+class LikesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_likeable
+
+  def create
+    @like = @likeable.likes.build(user: current_user)
+
+    if @like.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path }
+      end
+    end
+  end
+
+  def destroy
+    @like = current_user.likes.find_by!(likeable: @likeable)
+    @like.destroy!
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path }
+    end
+  end
+
+  private
+
+  def set_likeable
+    if params[:habit_id]
+      @likeable = Habit.find(params[:habit_id])
+
+    elsif params[:post_id]
+      @likeable = Post.find(params[:post_id])
+    end
+  end
+end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -2,6 +2,7 @@ class Habit < ApplicationRecord
   belongs_to :user
   has_many :habit_checks, dependent: :destroy
   has_many :comments, as: :commentable, dependent: :destroy # as: :commentableでhabit.commentsを取得。
+  has_many :likes, as: :likeable, dependent: :destroy # as: :likeableでhabit.likesを取得
 
   validates :title, presence: true, length: { maximum: 100 }
 

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :likeable, polymorphic: true
+
+  validates :user_id, uniqueness: { scope: [ :likeable_type, :likeable_id ] }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_one_attached :image # この記述でファイルアップロードを可能にする。postにimagesカラムを持たしたいのでpostに記述。
   has_many :comments, as: :commentable, dependent: :destroy # as: :commentableでpost.commentsを取得
+  has_many :likes, as: :likeable, dependent: :destroy # as: :likeableでpost.commentsを取得
 
   validates :title, presence: true
   validates :body, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :badges, through: :user_badges
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -12,5 +12,12 @@
     <%= f.submit "送信",
       class: "w-full bg-green-600 text-white py-2 rounded-lg hover:bg-green-700 transition" %>
   <% end %>
-</div>
 
+  <div class="flex text-center w-full mt-2">
+    <% if commentable.is_a?(Post) %>
+      <%= link_to "みんなの自然", posts_path, class:"w-full mb-5 bg-gray-600 text-white py-2 rounded-lg hover:bg-gray-700 transition" %>
+    <% elsif commentable.is_a?(Habit) %>
+      <%= link_to "みんなの習慣", public_habit_path, class:"w-full mb-5 bg-gray-600 text-white py-2 rounded-lg hover:bg-gray-700 transition" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/habits/_form.html.erb
+++ b/app/views/habits/_form.html.erb
@@ -1,12 +1,12 @@
 <%= form_with model: habit, local: true do |f| %>
   <div class="mb-5">
-    <%= f.label :title, "習慣タイトル", class: "block text-gray font-bold mb-1" %>
+    <%= f.label :title, "習慣タイトル(*必須)", class: "block text-gray font-bold mb-1" %>
     <%= f.text_field :title, class: "w-full border-2 border-green-500 p-2 rounded-lg focus:ring-2 focus:ring-green-600 focus:outline-none", placeholder: "「自然公園に行く」などなど" %>
     <p class="text-sm text-gray-500 mt-1">あなたが思う自然のことなら、どんなことでもOK!</p>
   </div>
 
   <div class="mb-5">
-    <%= f.label :frequency, "頻度", class: "block text-gray font-bold mb-1" %>
+    <%= f.label :frequency, "頻度(*必須)", class: "block text-gray font-bold mb-1" %>
     <%= f.select :frequency, Habit.frequencies.keys.map { |k| [t("activerecord.attributes.habit.frequency_values.#{k}"), k] }, {}, class: "w-full border-2 border-green-500 p-2 rounded-lg focus:ring-2 focus:ring-green-600 focus:outline-none" %>
     <p class="text-sm text-gray-500 mb-1">日常の些細な自然なら「毎日」をお出かけが必要なら「週に1回」など、習慣に合わせて頻度を選択してください。</p>
   </div>

--- a/app/views/habits/public_index.html.erb
+++ b/app/views/habits/public_index.html.erb
@@ -18,9 +18,16 @@
             <div class="bg-green-500 h-3 rounded-full transition-all duration-500" style="width: <%= habit.achievement_rate(habit.user, @week_start) %>%;"></div>
           </div>
 
-          <div class="flex items-center gap-1 text-gray-500 text-sm mt-2">
-            <span>💬</span>
-            <span><%= habit.comments.count %></span>
+          <div class="flex justify-end text-base gap-2 mt-3">
+            <div class="text-green-800">
+              <span>💚</span>
+              <span><%= habit.likes.count %></span>
+            </div>
+
+            <div class="text-gray-700">
+              <span>💬</span>
+              <span><%= habit.comments.count %></span>
+            </div>
           </div>
 
         </div>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -60,8 +60,11 @@
         <% end %>
       </div>
 
-      <!-- コメント数 -->
-      <div class="flex justify-end mt-5">
+      <div class="flex justify-between items-center mt-2">
+        <!-- いいね -->
+        <%= render "likes/like_button", likeable: @habit %>
+
+        <!-- コメント数 -->
         <h3 class="text-sm font-bold text-gray-700">
           <span id="comment_count">
             💬 コメント（<%= @habit.comments.count %>）
@@ -78,7 +81,7 @@
       </h3>
 
       <!-- コメントフォーム -->
-      <div id="comment_form" class="mb-6">
+      <div id="comment_form" class="mb-2">
         <%= render "comments/form", commentable: @habit, comment: Comment.new %>
       </div>
 

--- a/app/views/likes/_like_button.html.erb
+++ b/app/views/likes/_like_button.html.erb
@@ -1,0 +1,14 @@
+<div id="like_button_<%= likeable.id %>">
+  <% if current_user.likes.exists?(likeable: likeable) %>
+    <%= button_to "💚 #{likeable.likes.count}",
+      polymorphic_path([likeable, :like]),
+      method: :delete,
+      data: { turbo_method: :delete },
+      class: "text-green-500 text-3xl hover:text-green-600" %>
+  <% else %>
+    <%= button_to "🤍 #{likeable.likes.count}",
+      polymorphic_path([likeable, :like]),
+      method: :post,
+      class: "text-gray-500 text-3xl hover:text-gray-600" %>
+  <% end %>
+</div>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "like_button_#{@likeable.id}" do %>
+  <%= render "likes/like_button", likeable: @likeable %>
+<% end %>

--- a/app/views/likes/destroy.turbo_stream.erb
+++ b/app/views/likes/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "like_button_#{@likeable.id}" do %>
+  <%= render "likes/like_button", likeable: @likeable %>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,9 +32,16 @@
         <%= link_to "詳しく見る", post_path(post),
             class: "inline-block text-white bg-green-600 px-4 py-2 rounded-lg hover:bg-green-700 transition" %>
 
-        <div class="flex justify-end gap-1 text-gray-500 text-lg mt-2">
+        <div class="flex justify-end text-base gap-2 mt-3">
+          <div class="text-green-800">
+            <span>💚</span>
+            <span><%= post.likes.count %></span>
+          </div>
+
+          <div class="text-gray-700">
             <span>💬</span>
             <span><%= post.comments.count %></span>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,8 +23,11 @@
         投稿者：<%= @post.user.name %>
       </p>
 
-      <!-- コメント数 -->
-      <div class="flex justify-end mt-3">
+      <div class="flex justify-between items-center mt-3">
+        <!-- いいね -->
+        <%= render "likes/like_button", likeable: @post %>
+
+        <!-- コメント数 -->
         <h3 class="text-sm font-bold text-gray-700">
           <span id="comment_count">
             💬 コメント（<%= @post.comments.count %>）
@@ -40,7 +43,7 @@
       </h3>
 
       <!-- コメントフォーム -->
-      <div id="comment_form" class="mb-6">
+      <div id="comment_form" class="mb-2">
         <%= render "comments/form", commentable: @post, comment: Comment.new %>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   resources :habits, only: %i[ index new show edit create update destroy ] do
     resources :habit_checks, only: %i[ create destroy ] # habits_checksルート
     resources :comments, only: %i[ create destroy ] # habits用commentsルート
+    resource :like, only: %i[ create destroy ] # habits用likesルート
   end
 
   # 習慣公開ルート（みんなの習慣）
@@ -42,6 +43,7 @@ Rails.application.routes.draw do
   # postsルート
   resources :posts, only: %i[ index show new edit update create destroy ] do
     resources :comments, only: %i[ create destroy ] # posts用commentsルート
+    resource :like, only: %i[ create destroy ] # posts用likesルート
   end
 
   # Github Actionsでバッジ付与のタスクを自動で反映させるためのルート（Github Actionsで処理を叩かせる）

--- a/db/migrate/20251216015428_create_likes.rb
+++ b/db/migrate/20251216015428_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :likeable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+    add_index :likes, [ :user_id, :likeable_type, :likeable_id ], unique: true # DB側でもユーザ１人が一つの習慣・投稿につき1回のみいいね可能
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_12_221853) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_16_015428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,6 +87,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_12_221853) do
     t.index ["user_id"], name: "index_habits_on_user_id"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "likeable_type", null: false
+    t.bigint "likeable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable"
+    t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_id_and_likeable_type_and_likeable_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -126,6 +137,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_12_221853) do
   add_foreign_key "habit_checks", "habits"
   add_foreign_key "habit_checks", "users"
   add_foreign_key "habits", "users"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "user_badges", "badges"
   add_foreign_key "user_badges", "users"

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LikesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  likeable: one
+  likeable_type: Habit
+
+two:
+  user: two
+  likeable: two
+  likeable_type: Post

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
リアクション機能の実装
likeモデルを作成・db:migrate。コメント機能と同様に習慣にも投稿にもいいねができるように、polymorphicを使って実装。t.references :likeable, polymorphic: true, null: falseを記述。
ユーザー１人が一つの投稿・習慣に1回だけしかいいねできないよう、モデル・db側（マイグレーションファイル）で制約。
uniqueness・unique。
コメント同様に、ルート追記。リアクション機能のルートはresource（単数系）で記述。
likesコントローラー作成・編集。いいね機能もturbo_streamで非同期で実装。
対応するviews(_like_button.html.erb・create.turbo_stream.erb・destroy.turbo_stream.erb)を作成・編集
みんなの自然・みんなの習慣にて、いいね数を表示できるよう実装。
