### PR TITLE
LINE認証機能の実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
           # テスト環境でGoogleに通信しないようdummyを入れる（今だけ）
           GOOGLE_CLIENT_ID: dummy
           GOOGLE_CLIENT_SECRET: dummy
+          # LINEも同様にdummy入れとく（今だけ）
+          LINE_CLIENT_ID: dummy
+          LINE_CLIENT_SECRET: dummy
+
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,9 +5,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     callback("Google")
   end
 
-  # def line
-  # callback("LINE")
-  # end
+  def line
+    callback("LINE")
+  end
 
   private
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -41,16 +41,14 @@
         data: { turbo: false },
         class: "flex items-center justify-center w-full border border-gray-300 bg-white py-3 rounded-lg font-medium shadow-sm hover:bg-gray-50 transition" do %>
         <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google logo" class="w-5 h-5 mr-3">
-        <span class="text-gray-700">Googleで続ける</span>
+        <span class="text-gray-700">Googleではじめる</span>
       <% end %>
 
-      <!-- 
       <%= link_to user_line_omniauth_authorize_path,
         class: "flex items-center justify-center w-full bg-[#06C755] text-white py-3 rounded-lg font-medium shadow-sm hover:opacity-90 transition" do %>
         <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/LINE_logo.svg" alt="LINE logo" class="w-6 h-6 mr-3 bg-white rounded-sm p-0.5">
-        <span>LINEで続ける（工事中）</span>
+        <span>LINEではじめる</span>
       <% end %>
-      -->
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -35,13 +35,12 @@
         <span class="text-gray-700">Googleで続ける</span>
       <% end %>
 
-      <!-- 
+
       <%= link_to user_line_omniauth_authorize_path,
         class: "flex items-center justify-center w-full bg-[#06C755] text-white py-3 rounded-lg font-medium shadow-sm hover:opacity-90 transition" do %>
         <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/LINE_logo.svg" alt="LINE logo" class="w-6 h-6 mr-3 bg-white rounded-sm p-0.5">
-        <span>LINEで続ける（工事中）</span>
+        <span>LINEで続ける</span>
       <% end %>
-      -->
     </div>
 
     <div class="text-center text-green-600">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,9 +27,9 @@ Devise.setup do |config|
     }
 
   # LINE認証
-  # config.omniauth :line,
-  # ENV["LINE_CLIENT_ID"],
-  # ENV["LINE_CLIENT_SECRET"]
+  config.omniauth :line,
+    ENV["LINE_CLIENT_ID"],
+    ENV["LINE_CLIENT_SECRET"]
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.


### PR DESCRIPTION
LINE認証機能の実装

gem omniauth-lineをインストール。
LINE Developersで設定。
devise.rbにLINE用の設定を追記。Google認証と同様。
userモデル処理はGoogle認証時のものを使用。
omniauth_callbacks_controller.rbにdef line endの処理を追記。
LINE関連の環境変数を.envに追記。render側でも設定。