### PR TITLE
LINE認証の修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :verify_authenticity_token, only: [ :google_oauth2, :line ] # CSRFを一部外す
+
+
   def google_oauth2
     callback("Google")
   end


### PR DESCRIPTION
LINE認証の修正
omniauth_callbacks_controller.rbにskip_before_action :verify_authenticity_token, only: [ :google_oauth2, :line ]を追記し、CSRFを一部スキップするよう追記。