### PR TITLE
Github ActionsのLine Remindを手動確認できるよう追記

### DIFF
--- a/.github/workflows/line_reminder.yml
+++ b/.github/workflows/line_reminder.yml
@@ -3,6 +3,7 @@ name: "Line Remind"
 on:
   schedule:
     - cron: "0 11 * * *" # JST 20:00
+  workflow_dispatch:  # 手動で実行できるように追記
 
 jobs:
   send-reminder:


### PR DESCRIPTION
line_reminder.ymlにworkflow_dispatch:を追記し、手動確認してみる。