### PR TITLE
LINEリマインド機能修正

### DIFF
--- a/.github/workflows/line_reminder.yml
+++ b/.github/workflows/line_reminder.yml
@@ -25,5 +25,5 @@ jobs:
           LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
         run: |
-          bin/rails line_reminder:send
-
+          curl -X POST https://nature-habit.onrender.com/internal/line_reminder \
+            -H "X-INTERNAL-TOKEN: ${{ secrets.INTERNAL_API_TOKEN }}"

--- a/app/controllers/internal/line_reminders_controller.rb
+++ b/app/controllers/internal/line_reminders_controller.rb
@@ -1,0 +1,18 @@
+class Internal::LineRemindersController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate_internal!
+
+  def create
+    LineReminderSender.call
+    head :ok
+  end
+
+  private
+
+  def authenticate_internal!
+    token = request.headers["X-INTERNAL-TOKEN"]
+    unless token == ENV["INTERNAL_API_TOKEN"]
+      head :unauthorized
+    end
+  end
+end

--- a/app/helpers/internal/line_reminders_helper.rb
+++ b/app/helpers/internal/line_reminders_helper.rb
@@ -1,0 +1,2 @@
+module Internal::LineRemindersHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,5 +63,7 @@ Rails.application.routes.draw do
   # internal_badge_assign_path
   namespace :internal do
     post "badge_assign", to: "tasks#badge_assign"
+    # LINE通知タスク
+    post "line_reminder", to: "line_reminders#create"
   end
 end

--- a/test/controllers/internal/line_reminders_controller_test.rb
+++ b/test/controllers/internal/line_reminders_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Internal::LineRemindersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
LINEリマインド機能の修正

Github ActionsからrenderのDBを直接叩こうとしたら弾かれたので、badge付与処理同様に実装。
